### PR TITLE
Feature stdoutflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ module.exports = function(config) {
 };
 ```
 
-Optionally you can save report to a file
+Optionally you can save report to a file and turn off output the console
 ```js
 reporters: ['tap'],
 
 tapReporter: {
-  outputFile: './unit.tap'
+  outputFile: './unit.tap',
+  stdout: false 
 }
 ```
 ----

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var TAPReporter = function(baseReporterDecorator, config, logger) {
   var tapReporterConfig = config.tapReporter || {},
-    stdout = typeof reporterConfig.stdout !== 'undefined' ? reporterConfig.stdout : true,
+    stdout = typeof tapReporterConfig.stdout !== 'undefined' ? tapReporterConfig.stdout : true,
     log = logger.create('karma-tap-reporter'),
     _this = this,
     output = '',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var TAPReporter = function(baseReporterDecorator, config, logger) {
   var tapReporterConfig = config.tapReporter || {},
+    stdout = typeof reporterConfig.stdout !== 'undefined' ? reporterConfig.stdout : true,
     log = logger.create('karma-tap-reporter'),
     _this = this,
     output = '',
@@ -13,7 +14,9 @@ var TAPReporter = function(baseReporterDecorator, config, logger) {
    */
   function write(data) {
     output = output + data;
-    _this.write(data);
+    if (stdout) {
+      _this.write(data);
+    }
   }
 
   if (tapReporterConfig.outputFile) {


### PR DESCRIPTION
feat: config to turn off reporting to the console

This is a feature to allow turning off the reporting to the console (I know this isn't normal for TAP output, but our system is a little wonky and we just use the TAP files).